### PR TITLE
[ENHANCEMENT] Strapi: Update Development Port to 8082

### DIFF
--- a/backend/config/server.js
+++ b/backend/config/server.js
@@ -1,6 +1,6 @@
 module.exports = ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
+  port: env.int('PORT', 8082),
   admin: {
     auth: {
       secret: env('ADMIN_JWT_SECRET', '04daedfd89b4c0f8a1f47c8a9c322efc'),


### PR DESCRIPTION
Update development port for Strapi API and admin interface to 8082 on localhost to avoid conflicts on certain machines due to permissions.