### PR TITLE
[ENHANCEMENTS] Header Text Align, Cards and More

### DIFF
--- a/backend/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/backend/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "10/26/2020 11:02:07 PM"
+    "x-generation-date": "10/27/2020 10:05:56 AM"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/client-app/src/components/Header.vue
+++ b/client-app/src/components/Header.vue
@@ -84,6 +84,9 @@ export default {
       padding-right: 10px;
     }
   }
+  &.text {
+    text-align: right;
+  }
 }
 .avatar-link {
   padding: 0px !important;

--- a/client-app/src/components/Sidebar.vue
+++ b/client-app/src/components/Sidebar.vue
@@ -32,9 +32,6 @@ export default {
 </script>
 
 <style lang="scss">
-.b-sidebar {
-  top: 50px;
-}
 .b-sidebar > .b-sidebar-body {
   overflow-y: auto;
   background-color: #f5f5f5;

--- a/client-app/src/components/SwissMap.vue
+++ b/client-app/src/components/SwissMap.vue
@@ -46,7 +46,7 @@
       </sodipodi:namedview>
       <g id="layer6" inkscape:label="Cantons" inkscape:groupmode="layer">
         <path
-		@click="select({name:'OW', colour: '#E6E6E6'})"
+          @click="select({ name: 'OW', colour: '#E6E6E6' })"
           id="OW"
           class="canton"
           sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
@@ -71,7 +71,7 @@
 
         <path
           id="NW"
-		@click="select( { name: 'NW', colour: '#B3B3B3' } )"
+          @click="select({ name: 'NW', colour: '#B3B3B3' })"
           sodipodi:nodetypes="ccccccccccccccccccccccccccccsssccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path2580"
           fill="#B3B3B3"
@@ -92,7 +92,7 @@
 
         <path
           id="ZG"
-		@click="select( { name: 'ZG', colour: '#B3B3B3' } )"
+          @click="select({ name: 'ZG', colour: '#B3B3B3' })"
           sodipodi:nodetypes="cccccccccccccccccccccccccccccssscsssssssssscccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3458"
           fill="#B3B3B3"
@@ -115,7 +115,7 @@
 
         <path
           id="LU"
-		@click="select( { name: 'LU', colour: '#808080' } )"
+          @click="select({ name: 'LU', colour: '#808080' })"
           sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3429"
           fill="#808080"
@@ -148,7 +148,7 @@
 
         <path
           id="AG"
-		@click="select( { name: 'AG', colour: '#E6E6E6' } )"
+          @click="select({ name: 'AG', colour: '#E6E6E6' })"
           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccsssscsssssssssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsssssssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssc"
           inkscape:label="#path3775"
           fill="#E6E6E6"
@@ -213,7 +213,7 @@
 
         <path
           id="BL"
-		@click="select( { name: 'BL', colour: '#999999' } )"
+          @click="select({ name: 'BL', colour: '#999999' })"
           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccssssssssccccccccccccccccccccccccccccccccccccccccccccccccccccccssc"
           inkscape:label="#path3573"
           fill="#999999"
@@ -245,7 +245,7 @@
 
         <path
           id="VS"
-		@click="select( { name: 'VS', colour: '#E6E6E6' } )"
+          @click="select({ name: 'VS', colour: '#E6E6E6' })"
           sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccsssssssssssssssssssssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path2579"
           fill="#E6E6E6"
@@ -293,7 +293,7 @@
 
         <path
           id="BE"
-		@click="select( { name: 'BE', colour: '#CCCCCC' } )"
+          @click="select({ name: 'BE', colour: '#CCCCCC' })"
           sodipodi:nodetypes="ccccccccccccccccccccssssssssssssscccscccccsssssssssssssssssccccccccccccccccccsssssssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsssssssssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsssssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccscccccccccccccccccccccccscscccccccccccccsccccc"
           inkscape:label="#path2577"
           fill="#CCCCCC"
@@ -366,7 +366,7 @@
 
         <path
           id="SO"
-		@click="select( { name: 'SO', colour: '#808080' } )"
+          @click="select({ name: 'SO', colour: '#808080' })"
           sodipodi:nodetypes="ccccccccccccccccccccccccsssssssssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsssssssssssssssccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsccccccccccccccccccccccccccccccscc"
           inkscape:label="#path3741"
           fill="#808080"
@@ -416,7 +416,7 @@
 
         <path
           id="JU"
-		@click="select( { name: 'JU', colour: '#B3B3B3' } )"
+          @click="select({ name: 'JU', colour: '#B3B3B3' })"
           sodipodi:nodetypes="cssssssccccccccccccccccccccccccccccccccccccccccccccccccccccccccssssssssssssssssssssssssssccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3583"
           fill="#B3B3B3"
@@ -449,7 +449,7 @@
         />
         <path
           id="VD"
-		@click="select( { name: 'VD', colour: '#808080' } )"
+          @click="select({ name: 'VD', colour: '#808080' })"
           inkscape:label="#path3824"
           fill="#808080"
           stroke="#22241C"
@@ -496,7 +496,7 @@
 
         <path
           id="FR"
-		@click="select( { name: 'FR', colour: '#999999' } )"
+          @click="select({ name: 'FR', colour: '#999999' })"
           sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccssssssssssssssssscccccscccssssssssssssscccccccccccccccccccccccccccccccsccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3531"
           fill="#999999"
@@ -540,7 +540,7 @@
 
         <path
           id="BS"
-		@click="select( { name: 'BS', colour: '#CCCCCC' } )"
+          @click="select({ name: 'BS', colour: '#CCCCCC' })"
           sodipodi:nodetypes="ccccccccccccccccccccccccccccc"
           inkscape:label="#path3716"
           fill="#CCCCCC"
@@ -554,7 +554,7 @@
 
         <path
           id="GE"
-		@click="select( { name: 'GE', colour: '#B3B3B3' } )"
+          @click="select({ name: 'GE', colour: '#B3B3B3' })"
           sodipodi:nodetypes="cccccccccccccccccccccccsccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3853"
           fill="#B3B3B3"
@@ -574,7 +574,7 @@
 
         <path
           id="NE"
-		@click="select( { name: 'NE', colour: '#E6E6E6' } )"
+          @click="select({ name: 'NE', colour: '#E6E6E6' })"
           sodipodi:nodetypes="cssssssssccccccccccccccccccccccccccccccccccccccccccccccccccccccccsssssssccccccccccccccccccccc"
           inkscape:label="#path2553"
           fill="#E6E6E6"
@@ -599,7 +599,7 @@
 
         <path
           id="GR"
-		@click="select( { name: 'GR', colour: '#E6E6E6' } )"
+          @click="select({ name: 'GR', colour: '#E6E6E6' })"
           sodipodi:nodetypes="ccccccccccccsccccccccccccccccccccccccccccccccccccccccccccccssssccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccssssssccssssscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3788"
           fill="#E6E6E6"
@@ -662,7 +662,7 @@
         />
         <path
           id="SG"
-		@click="select( { name: 'SG', colour: '#808080' } )"
+          @click="select({ name: 'SG', colour: '#808080' })"
           fill="#808080"
           stroke="#22241C"
           stroke-width="0.5"
@@ -722,7 +722,7 @@
 
         <path
           id="SZ"
-		@click="select( { name: 'SZ', colour: '#E6E6E6' } )"
+          @click="select({ name: 'SZ', colour: '#E6E6E6' })"
           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3472"
           fill="#E6E6E6"
@@ -749,7 +749,7 @@
 
         <path
           id="AI"
-		@click="select( { name: 'AI', colour: '#999999' } )"
+          @click="select({ name: 'AI', colour: '#999999' })"
           sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3711"
           fill="#999999"
@@ -767,7 +767,7 @@
 
         <path
           id="AR"
-		@click="select( { name: 'AR', colour: '#CCCCCC' } )"
+          @click="select({ name: 'AR', colour: '#CCCCCC' })"
           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3719"
           fill="#CCCCCC"
@@ -788,7 +788,7 @@
 
         <path
           id="TG"
-		@click="select( { name: 'TG', colour: '#B3B3B3' } )"
+          @click="select({ name: 'TG', colour: '#B3B3B3' })"
           sodipodi:nodetypes="csssssssssssssssssssssssssscccccccccccccccccccccccccccccccsscccccccccccccccccccccccccccsssccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3650"
           fill="#B3B3B3"
@@ -825,7 +825,7 @@
 
         <path
           id="ZH"
-		@click="select( { name: 'ZH', colour: '#CCCCCC' } )"
+          @click="select({ name: 'ZH', colour: '#CCCCCC' })"
           sodipodi:nodetypes="cccccccccccccccccccccccccccccssscsssscccccccccccccccccccccccccccccccccccssssscsssssssssssssscssssssssssssssscsssssssssssscccccccccccccccccccccccccccccccsscccccccccccccccccccccccccccssscccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3546"
           fill="#CCCCCC"
@@ -873,7 +873,7 @@
         />
         <path
           id="SH"
-		@click="select( { name: 'SH', colour: '#999999' } )"
+          @click="select({ name: 'SH', colour: '#999999' })"
           inkscape:label="#path3624"
           fill="#999999"
           stroke="#22241C"
@@ -912,7 +912,7 @@
 
         <path
           id="GL"
-		@click="select( { name: 'GL', colour: '#B3B3B3' } )"
+          @click="select({ name: 'GL', colour: '#B3B3B3' })"
           sodipodi:nodetypes="cssssscccccccccccccccccccccccccccccccccccccccccccccccscccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3777"
           fill="#B3B3B3"
@@ -937,7 +937,7 @@
 
         <path
           id="UR"
-		@click="select( { name: 'UR', colour: '#999999' } )"
+          @click="select({ name: 'UR', colour: '#999999' })"
           sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3800"
           fill="#999999"
@@ -966,7 +966,7 @@
 
         <path
           id="TI"
-		@click="select( { name: 'TI', colour: '#808080' } )"
+          @click="select({ name: 'TI', colour: '#808080' })"
           sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccsccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
           inkscape:label="#path3896"
           fill="#808080"
@@ -4348,33 +4348,38 @@
 <script>
 export default {
   name: "SwissMap",
-  data(){
-	return{
-	selectedCanton: {
-		name: "",
-		colour: "",
-	},
-	}
+  data() {
+    return {
+      selectedCanton: {
+        name: "",
+        colour: "",
+      },
+    };
   },
-  methods:{
-	select(canton){
-		if(this.selectedCanton.name != ""){
-			document.getElementById(this.selectedCanton.name).style.fill = this.selectedCanton.colour;
-		}
-		document.getElementById(canton.name).style.fill = "var(--dark-primary)";
-		this.selectedCanton = canton;
-	}
-  }
+  methods: {
+    select(canton) {
+      if (this.selectedCanton.name != "") {
+        document.getElementById(
+          this.selectedCanton.name
+        ).style.fill = this.selectedCanton.colour;
+      }
+      document.getElementById(canton.name).style.fill = "var(--dark-primary)";
+      this.selectedCanton = canton;
+    },
+  },
 };
 </script>
 
 <style lang="scss">
-#layer6{
-	path{
-		&:hover{
-			fill:var(--dark-primary);
-			cursor:pointer;
-		}
-	}
+#layer6 {
+  path {
+    &:hover {
+      fill: var(--dark-primary);
+      cursor: pointer;
+    }
+  }
+}
+.swiss-map {
+  text-align: center;
 }
 </style>

--- a/client-app/src/components/Tutorial/Card.vue
+++ b/client-app/src/components/Tutorial/Card.vue
@@ -1,8 +1,7 @@
 <template>
-  <div class="tutorial-block">
+  <div class="tutorial-block p-1">
     <div class="title-container">
-      <div class="placeholder"></div>
-      <div class="tutorial-title">{{ tutorial.name }}</div>
+      <div class="tutorial-title text-left ml-3">{{ tutorial.name }}</div>
     </div>
     <div class="body-container">
       <div class="display-image-container">
@@ -27,7 +26,7 @@
         </div>
       </div>
     </div>
-    <div class="footer-container">
+    <div class="footer-container align-items-center p-1">
       <div class="details">
         <img :src="tutorial.imgsrc" alt="complexity" />
         <img :src="tutorial.imgsrc" alt="type" />

--- a/client-app/src/main.js
+++ b/client-app/src/main.js
@@ -1,35 +1,34 @@
 import "@babel/polyfill";
-import "mutationobserver-shim";
-import Vue from "vue";
-import "./plugins/bootstrap-vue";
-import "./plugins/axios";
-import "./plugins/strapi";
-import App from "./App.vue";
-import router from "./router";
-import store from "./store";
-
 import { library } from "@fortawesome/fontawesome-svg-core";
 import {
-  faUserSecret,
-  faCogs,
-  faHome,
   faChalkboard,
-  faSearch,
+  faCode,
+  faCogs,
+  faComment,
+  faEdit,
+  faExclamation,
+  faExpand,
   faHeart,
+  faHome,
   faPaw,
   faPlus,
-  faCode,
-  faEdit,
-  faSave,
   faRuler,
-  faComment,
-  faExpand,
-  faShare,
-  faExclamation,
+  faSave,
   faSchool,
+  faSearch,
+  faShare,
+  faUserSecret,
 } from "@fortawesome/free-solid-svg-icons";
-
 import "highlight.js/styles/atom-one-dark.css";
+import "mutationobserver-shim";
+import Vue from "vue";
+import App from "./App.vue";
+import "./plugins/axios";
+import "./plugins/bootstrap-vue";
+import "./plugins/strapi";
+import router from "./router";
+import store from "./store";
+import "./utils/filters";
 
 library.add(faUserSecret);
 library.add(faCogs);

--- a/client-app/src/utils/filters.js
+++ b/client-app/src/utils/filters.js
@@ -1,0 +1,27 @@
+import Vue from "vue";
+
+Vue.filter("chf", function(value) {
+  if (!value) return "";
+  return (
+    new Number(value).toLocaleString("de-CH", {
+      minimumFractionDigits: 2,
+    }) + " CHF"
+  );
+});
+
+Vue.filter("medium", function(value) {
+  if (!value) return "";
+  var count = 35;
+  return value.slice(0, count) + (value.length > count ? "..." : "");
+});
+
+Vue.filter("long", function(value) {
+  if (!value) return "";
+  var count = 250;
+  return value.slice(0, count) + (value.length > count ? "..." : "");
+});
+
+Vue.filter("capitalize", function(value) {
+  if (!value) return "";
+  return value.toUpperCase();
+});

--- a/client-app/src/views/Forum.vue
+++ b/client-app/src/views/Forum.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="forum">
     <div class="post-container" v-for="post in posts" :key="post.id">
-      <div class="post">
+      <div class="post" style="height: 100%">
         <div class="left-align">
           <span
             ><FontAwesomeIcon class="icon fa-sm" icon="paw" />
             {{ post.likes }}</span
           >
         </div>
-        <div class="right-align">
+        <div class="right-align d-flex flex-column">
           <div class="author">
             <div class="d-flex justify-content-between">
               <span>
@@ -29,11 +29,10 @@
               </span>
             </div>
           </div>
-          <div class="body">
-            {{ post.body.substring(0, 250) }}
-            {{ post.body.substring(250) && "..." }}
+          <div class="body" style="flex: 1">
+            {{ post.body | long }}
           </div>
-          <div class="footer">
+          <div class="footer pb-1 my-1 ml-2">
             <div class="actions">
               <span>
                 {{ post.comments.length }}

--- a/client-app/src/views/Internships.vue
+++ b/client-app/src/views/Internships.vue
@@ -1,36 +1,34 @@
 <template>
   <div class="internships">
-    <SwissMap  style="padding-bottom:5px;"/>
-    <p class="title">Internships</p>
+    <b-jumbotron
+      header="Internships"
+      lead="Find your next dream job here."
+    >
+    </b-jumbotron>
+    <SwissMap style="padding-bottom: 5px" />
     <div
       class="card-container d-flex flex-wrap justify-content-between p-2 align-content-center"
     >
-      <div
+      <b-card
         v-for="intern in internships"
         :key="intern.id"
-        class="card m-2"
+        class="m-2 internship-card"
         style="flex: 1"
+        :title="intern.company"
       >
-        <div class="header">
-          <div class="header-content">
-            <span style="padding-left: 5px; padding-right: 5px">{{
-              intern.company
-            }}</span>
+        <div class="card-content">
+          <div class="d-flex justify-content-between mb-4">
+            <h6 class="card-subtitle text-muted m-0">{{ intern.type }}</h6>
+            <b-card-text>
+              <div class="d-flex flex-column">
+                <span>{{ intern.pay | chf }}</span>
+                <span class="font-weight-bold">{{ intern.location }}</span>
+              </div>
+            </b-card-text>
           </div>
+          <b-card-text>{{ intern.description }}</b-card-text>
         </div>
-        <div class="body">
-          <div class="offer-details-container">
-            <p>{{ intern.type }}</p>
-            <div class="offer-details">
-              <span>{{ intern.pay }} ChF</span>
-              <span>{{ intern.location }}</span>
-            </div>
-          </div>
-          <p style="padding-left: 5px; padding-right: 5px">
-            {{ intern.description }}
-          </p>
-        </div>
-      </div>
+      </b-card>
     </div>
   </div>
 </template>
@@ -54,16 +52,16 @@ export default {
           type: "Fullstack",
           location: "Alpnach",
           description:
-            "Work description for internship at Company1 filler filler filler filler filler filler filler filler filler filler filler",
+            "Description 1\n\nLorem ipsum dolor sit amet consectetur adipisicing elit. Iure delectus distinctio impedit ratione, velit nulla quasi, ea quod nobis eaque modi aliquid enim quis vel quaerat optio et harum laboriosam.",
         },
         {
           id: 2,
           company: "Company2",
           pay: "1500",
-          type: "FrontEnd",
+          type: "Frontend",
           location: "Baden",
           description:
-            "Work description for internship at Company2 filler filler filler filler filler filler filler filler filler filler filler filler filler filler",
+            "Description 2\n\nLorem ipsum dolor sit amet consectetur adipisicing elit. Iure delectus distinctio impedit ratione, velit nulla quasi, ea quod nobis eaque modi aliquid enim quis vel quaerat optio et harum laboriosam.",
         },
       ],
     };
@@ -77,28 +75,20 @@ export default {
   margin-bottom: 10px;
   margin-left: 5px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-  .title {
-    background-color: var(--dark-primary);
-    color: var(--white);
-    padding: 10px;
-  }
-  .header {
-    padding-top: 10px;
-    .header-content {
-      font-weight: bold;
-      color: var(--dark-primary);
+
+  .internship-card {
+    .card-body {
+      padding: 0;
     }
-  }
-  .body {
-    .offer-details-container {
-      display: flex;
-      justify-content: space-between;
-      margin: 5px;
-      .offer-details {
-        display: flex;
-        flex-direction: column;
-        text-align: right;
-      }
+
+    .card-title {
+      background-color: var(--dark-primary);
+      color: var(--white);
+      padding: 10px;
+    }
+
+    .card-content {
+      padding: 1.25rem;
     }
   }
 }

--- a/client-app/src/views/Tutorials.vue
+++ b/client-app/src/views/Tutorials.vue
@@ -3,7 +3,7 @@
     <SearchBar />
     <div class="description-container">
       <div class="description-container">
-        <div class="description-block">
+        <div class="description-block p-3">
           <div class="text-container">
             <span class="description-title">Create your own Tutorial</span>
             <span class="description-body">
@@ -17,7 +17,7 @@
             </router-link>
           </div>
         </div>
-        <div class="description-block">
+        <div class="description-block p-3">
           <div class="text-container">
             <span class="description-title">Become a moderator</span>
             <span class="description-body">
@@ -45,6 +45,7 @@
 <script>
 import SearchBar from "@/components/SearchBar";
 import TutorialCard from "@/components/Tutorial/Card";
+
 export default {
   name: "Tutorials",
   components: {

--- a/client-app/src/views/Tutoring.vue
+++ b/client-app/src/views/Tutoring.vue
@@ -4,37 +4,41 @@
     <div
       class="card-container d-flex flex-wrap justify-content-between p-2 align-content-center"
     >
-      <div
+      <b-card
         v-for="tutor in tutors"
         :key="tutor.id"
         class="card m-2"
         style="flex: 1"
       >
         <div class="header">
-          <b-avatar class="mx-2"></b-avatar>
+          <b-avatar class="mb-3"></b-avatar>
           <div class="header-content">
-            <span>{{ tutor.name }}</span>
+            <p style="margin-bottom: 0.35rem">{{ tutor.name }}</p>
             <div class="d-flex header-content-score">
               <p class="mb-0">
                 <FontAwesomeIcon class="icon fa-sm" icon="paw" />
               </p>
-              <p class="mb-0 mr-1 score">{{ tutor.score }}</p>
+              <p class="mb-2 mr-1 score">{{ tutor.score }}</p>
             </div>
           </div>
         </div>
-        <div class="body">
-          <div class="offer-details-container">
-            <p>{{ tutor.category }}</p>
-            <div class="offer-details">
-              <span>{{ tutor.pay }} ChF</span>
-              <span>{{ tutor.location }}</span>
-            </div>
+        <div class="card-content">
+          <div class="d-flex justify-content-between mb-4">
+            <h6 class="card-subtitle text-muted m-0">{{ tutor.category }}</h6>
+            <b-card-text>
+              <div class="d-flex flex-column">
+                <span v-if="Array.isArray(tutor.payRange)">
+                  {{ tutor.payRange[0] | chf }} -
+                  {{ tutor.payRange[1] | chf }}
+                </span>
+                <span v-else>{{ tutor.payRange | chf }}</span>
+                <span class="font-weight-bold">{{ tutor.location }}</span>
+              </div>
+            </b-card-text>
           </div>
-          <p>{{ tutor.description }}</p>
+          <b-card-text>{{ tutor.description }}</b-card-text>
         </div>
-        <div></div>
-        <p></p>
-      </div>
+      </b-card>
     </div>
   </div>
 </template>
@@ -55,7 +59,7 @@ export default {
           name: "Developer 1",
           score: 6520,
           category: "Fullstack",
-          pay: "10",
+          payRange: "10",
           location: "Aarau",
           description:
             "Fullstack engineer trying to help students get a better understanding of the matter.",
@@ -64,8 +68,8 @@ export default {
           id: 2,
           name: "Developer 1",
           score: 6520,
-          category: "FrontEnd",
-          pay: "15-20",
+          category: "Frontend",
+          payRange: ["15", "20"],
           location: "Baden",
           description:
             "Fullstack engineer trying to help students get a better understanding of the matter.",
@@ -82,11 +86,13 @@ export default {
   margin-bottom: 10px;
   margin-right: 5px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+
   .title {
     background-color: var(--dark-primary);
     color: var(--white);
     padding: 10px;
   }
+
   .card-container {
     .card {
       .header {
@@ -94,12 +100,15 @@ export default {
         color: var(--dark-primary);
         border-bottom: #dae0e6 solid 1px;
         text-align: center;
+
         .header-content {
           text-align: center;
           padding-top: 5px;
           line-height: 1;
+
           .header-content-score {
             justify-content: center;
+
             .score {
               font-size: 14px;
               position: relative;
@@ -109,18 +118,13 @@ export default {
           }
         }
       }
-      .body {
-        .offer-details-container {
-          .offer-details {
-            display: flex;
-            flex-direction: column;
-            flex-wrap: wrap;
-            justify-content: flex-end;
-          }
-          display: flex;
-          justify-content: space-between;
-          margin: 3px;
-        }
+
+      .card-body {
+        padding: 0;
+      }
+
+      .card-content {
+        padding: 1.25rem;
       }
     }
   }


### PR DESCRIPTION
# Overview

This PR includes purely cosmetical upgrades to the frontend with new styles, use of Bootstrap components and Vue filters.

## Header

The header text has been aligned to the right; the solution is imperfect though and Bootstrap's navbar component should be correctly utilized with an `mr-auto` filler `div`.

## Filters

Vue text filters for truncating long and medium texts have been added, limiting the value to 250 characters and 50 characters respectively. A `chf` filter to convert numbers to the `XX.XX CHF` format is included as well as a capitalization utility.

## Tutorials

Additional padding has been added to the tutorial cards and the informational layouts.

## Posts

The styling of post cards has been updated with more padding and some flex utilities to ensure cards expand their body in larger rows.

## Internships

The internship overview page uses the Bootstrap card component and additional Bootstrap classes in place of custom styles to create a more responsive layout and additional padding.

A jumbotron has been placed for the title above the Swiss map with a lead text and the Swiss map is now positioned centered on larger screens.

## Tutors

The tutor cards now use the Bootstrap card component as well as some custom styling added to the header, subtitle and `.card-body` to retain the previous layout.